### PR TITLE
update adapter to allow for falsy values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcc-code/feathers-arangodb",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcc-code/feathers-arangodb",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "ArangoDB Service/Adapter for FeathersJS",
   "homepage": "https://github.com/AnatidaeProject/feathers-arangodb",
   "main": "lib/",

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -175,18 +175,20 @@ export class QueryBuilder {
 
 
   addFilter(key: string, value: any, docName: string = "doc", operator = ""): QueryBuilder {
-
     const stack = (fOpt: string, arg1: AqlValue, arg2: AqlValue, equality: AqlValue) => {
       this.filter = aql.join([this.filter, arg1, equality, arg2], " ");
       delete value[fOpt];
       return this.addFilter(key, value, docName, operator);
     };
 
-    const valueIsAPrimitiveType = _isString(value) || _isBoolean(value) || _isNumber(value)
-    const stringValueOfvalue: any = Object.keys(value)[0]
+    const valueIsAPrimitiveType = _isString(value) || _isBoolean(value) || _isNumber(value) || value === null
+    let stringValueOfvalue = ''
+    if(!valueIsAPrimitiveType)
+      stringValueOfvalue = Object.keys(value)[0]
+
     const valueIsAReservedWord = this.reserved.includes(stringValueOfvalue)
 
-    if ((typeof value === "object" && _isEmpty(value))) return this;
+    if ((_isObject(value) && _isEmpty(value))) return this;
 
     if (this.filter == null) {
       this.filter = aql``;
@@ -204,56 +206,56 @@ export class QueryBuilder {
         " "
       );
       return this;
-    } else if (typeof value === "object" && value["$in"]) {
+    } else if (typeof value === "object" && value["$in"] !== undefined) {
       return stack(
         "$in",
         aql`${value["$in"]}`,
         aql.literal(`${docName}.${key}`),
         aql.literal("ANY ==")
       );
-    } else if (typeof value === "object" && value["$nin"]) {
+    } else if (typeof value === "object" && value["$nin"] !== undefined) {
       return stack(
         "$nin",
         aql`${value["$nin"]}`,
         aql.literal(`${docName}.${key}`),
         aql.literal("NONE ==")
       );
-    } else if (typeof value === "object" && value["$not"]) {
+    } else if (typeof value === "object" && value["$not"] !== undefined) {
       return stack(
         "$not",
         aql.literal(`${docName}.${key}`),
         aql`${value["$not"]}`,
         aql.literal("!=")
       );
-    } else if (typeof value === "object" && value["$lt"]) {
+    } else if (typeof value === "object" && value["$lt"] !== undefined) {
       return stack(
         "$lt",
         aql.literal(`${docName}.${key}`),
         aql`${value["$lt"]}`,
         aql.literal("<")
       );
-    } else if (typeof value === "object" && value["$lte"]) {
+    } else if (typeof value === "object" && value["$lte"] !== undefined) {
       return stack(
         "$lte",
         aql.literal(`${docName}.${key}`),
         aql`${value["$lte"]}`,
         aql.literal("<=")
       );
-    } else if (typeof value === "object" && value["$gt"]) {
+    } else if (typeof value === "object" && value["$gt"] !== undefined) {
       return stack(
         "$gt",
         aql.literal(`${docName}.${key}`),
         aql`${value["$gt"]}`,
         aql.literal(">")
       );
-    } else if (typeof value === "object" && value["$gte"]) {
+    } else if (typeof value === "object" && value["$gte"] !== undefined) {
       return stack(
         "$gte",
         aql.literal(`${docName}.${key}`),
         aql`${value["$gte"]}`,
         aql.literal(">=")
       );
-    } else if (typeof value === "object" && value["$ne"]) {
+    } else if (typeof value === "object" && value["$ne"] !== undefined) {
       return stack(
         "$ne",
         aql.literal(`${docName}.${key}`),

--- a/tests/feathers.tests.ts
+++ b/tests/feathers.tests.ts
@@ -269,6 +269,65 @@ describe(`Feathers common tests, ${serviceName} service with \\${idProp}\\ id pr
       expect(result[0].name).to.eq('Alice');
     });
 
+    describe('falsy values', () => {
+
+      beforeEach(async () => {
+        const philip = await service.create({ name: 'Philip', age: 0});
+        _ids.philip = philip[idProp];
+        const steven = await service.create({ name: 'Steven'});
+        _ids.steven = steven[idProp];
+      });
+
+      it('can $ne to 0', async () => {
+        const params = {
+          query: {age: {$ne: 0}, $sort: {name: 1}}
+        }
+        const result = <Array<any>>await service.find(params)
+        expect(result.length).to.eq(4)
+        expect(result[0].name).to.eq('Alice')
+        expect(result[1].name).to.eq('Bob')
+        expect(result[2].name).to.eq('Doug')
+        expect(result[3].name).to.eq('Steven')
+      })
+
+      it('can $gt than 0', async () => {
+        const params = {
+          query: {age: {$gt: 0}, $sort: {name: 1}}
+        }
+        const result = <Array<any>>await service.find(params)
+        expect(result.length).to.eq(3)
+        expect(result[0].name).to.eq('Alice')
+        expect(result[1].name).to.eq('Bob')
+        expect(result[2].name).to.eq('Doug')
+      })
+
+      it('can $ne to null', async () => {
+        const params = {
+          query: {age: {$ne: null}, $sort: {name: 1}}
+        }
+        const result = <Array<any>>await service.find(params)
+        expect(result.length).to.eq(4)
+        expect(result[0].name).to.eq('Alice')
+        expect(result[1].name).to.eq('Bob')
+        expect(result[2].name).to.eq('Doug')
+        expect(result[3].name).to.eq('Philip')
+      })
+
+      it('can equal to null', async () => {
+        const params = {
+          query: {age: null}
+        }
+        const result = <Array<any>>await service.find(params)
+        expect(result.length).to.eq(1)
+        expect(result[0].name).to.eq('Steven')
+      })
+
+      afterEach(async () => {
+        await service.remove(_ids.philip);
+        await service.remove(_ids.steven);
+      });
+    })
+
     describe('special filters', () => {
 
       it('can $sort', async () => {


### PR DESCRIPTION
The change allows for queries that were previously not working:
1. {query: {age: null}} (to get all the documents without age attribute)
2. {query: {age: {$ne: null}}} (to get all the documents with age attribute)
3. {query: {age: {$gt: 0}}} (to get all the docuemtns with age greater than 0)
And many others involving falsy values